### PR TITLE
Get Android to work

### DIFF
--- a/SDLCore/RemoteApplication.swift
+++ b/SDLCore/RemoteApplication.swift
@@ -143,7 +143,7 @@ extension RemoteApplication {
                                        frameType: .single,
                                        serviceType: .rpc,
                                        controlCmd: .heartbeat,
-                                       sessionID: 1,
+                                       sessionID: 0,
                                        functionID: .onHMIStatus,
                                        correlationID: 0)
         isAudible = audible

--- a/SDLCore/SDLMessage.swift
+++ b/SDLCore/SDLMessage.swift
@@ -291,7 +291,13 @@ class SDLMessage {
         msg = SDLMessage.init(rawMsg: data)
         guard let safeMsg = msg else { return msg }
         if safeMsg.bytesInPayload > 0 {
-            guard let payload = client.read(Int(safeMsg.bytesInPayload)) else { return msg } // Read payload
+            var remaining = Int(safeMsg.bytesInPayload)
+            var payload = [Byte]()
+            while(remaining > 0) {
+                guard let buffer = client.read(remaining) else { return msg } // Read payload
+                payload += buffer
+                remaining -= buffer.count
+            }
             //print("Recv'd Payload \(payload.count) bytes")
             safeMsg.setPayload(Data.init(payload))
         }


### PR DESCRIPTION
- Force the session id to 0 (assuming only 1 app is connected)
- Loop reading the payload if it does not get the full data